### PR TITLE
feat(windows): запуск от имени администратора по умолчанию (requireAdministrator)

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -166,9 +166,24 @@ fn main() {
         relay, exits
     );
 
+    println!("cargo:rerun-if-env-changed=AG_NO_ADMIN_MANIFEST");
+
     if env::var("CARGO_CFG_TARGET_OS").unwrap() == "windows" {
         let mut res = winres::WindowsResource::new();
         res.set_icon("icon.ico");
+        if env::var("AG_NO_ADMIN_MANIFEST").is_err() {
+            res.set_manifest(r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+        <security>
+            <requestedPrivileges>
+                <requestedExecutionLevel level="requireAdministrator" uiAccess="false" />
+            </requestedPrivileges>
+        </security>
+    </trustInfo>
+</assembly>
+"#);
+        }
         res.set("FileDescription", "Antigravity Configuration Tool");
         res.set("ProductName", "Antigravity Configurator");
         res.set("LegalCopyright", "Brent t.me/nova_txt");

--- a/src/background.rs
+++ b/src/background.rs
@@ -176,12 +176,12 @@ mod windows_impl {
              $d='Antigravity Unlocker: локальный DNS-релей'; \
              try {{ \
                $p=New-ScheduledTaskPrincipal -UserId \"$env:USERDOMAIN\\$env:USERNAME\" \
-                    -LogonType S4U -RunLevel Limited; \
+                    -LogonType S4U -RunLevel Highest; \
                Register-ScheduledTask -TaskName '{task}' -Action $a -Trigger $t -Settings $s \
                     -Principal $p -Description $d -Force -ErrorAction Stop | Out-Null }} \
-             catch {{ \
+             catch {{ $p=New-ScheduledTaskPrincipal -UserId \"$env:USERDOMAIN\\$env:USERNAME\" -RunLevel Highest; \
                Register-ScheduledTask -TaskName '{task}' -Action $a -Trigger $t -Settings $s \
-                    -Description $d -Force -ErrorAction Stop | Out-Null }}; \
+                    -Principal $p -Description $d -Force -ErrorAction Stop | Out-Null }}; \
              Start-ScheduledTask -TaskName '{task}'",
             exe = dst.display(),
             flag = FORWARDER_FLAG,
@@ -320,12 +320,12 @@ mod windows_impl {
              $d='Antigravity Unlocker: сторож патча'; \
              try {{ \
                $p=New-ScheduledTaskPrincipal -UserId \"$env:USERDOMAIN\\$env:USERNAME\" \
-                    -LogonType S4U -RunLevel Limited; \
+                    -LogonType S4U -RunLevel Highest; \
                Register-ScheduledTask -TaskName '{task}' -Action $a -Trigger $t -Settings $s \
                     -Principal $p -Description $d -Force -ErrorAction Stop | Out-Null }} \
-             catch {{ \
+             catch {{ $p=New-ScheduledTaskPrincipal -UserId \"$env:USERDOMAIN\\$env:USERNAME\" -RunLevel Highest; \
                Register-ScheduledTask -TaskName '{task}' -Action $a -Trigger $t -Settings $s \
-                    -Description $d -Force -ErrorAction Stop | Out-Null }}; \
+                    -Principal $p -Description $d -Force -ErrorAction Stop | Out-Null }}; \
              Start-ScheduledTask -TaskName '{task}' -ErrorAction SilentlyContinue",
             exe = exe.display(),
             flag = WATCHDOG_FLAG,


### PR DESCRIPTION
### Описание изменений
Для работы ключевых компонентов обхода (правила DNS NRPT, установка службы, изменение настроек сети) в Windows требуются права администратора. Ранее приложение запускалось без манифеста и при обычном запуске требовало ручного нажатия кнопки перезапуска от имени администратора.

Данный PR:
1. **Встраивает манифест UAC (`requireAdministrator`)** в сборку под Windows (`build.rs`). Теперь при обычном запуске (двойным кликом / через ярлык) Windows по умолчанию запрашивает права администратора через стандартный диалог UAC.
2. **Обновляет регистрацию задач в планировщике Windows** (`src/background.rs`): фоновые задачи (`--dns-forwarder`, `--watchdog`) регистрируются с `-RunLevel Highest`, чтобы планировщик мог корректно запускать бинарник с манифестом администратора при входе в систему.
3. **Обеспечивает запуск тестов**: добавлена проверка переменной окружения `AG_NO_ADMIN_MANIFEST`, позволяющая при необходимости собирать и запускать `cargo test` в не-elevated окружении (например, в локальном терминале или CI).
4. **Не затрагивает Linux**: изменения строго изолированы под `CARGO_CFG_TARGET_OS == "windows"` и `#[cfg(target_os = "windows")]`.
